### PR TITLE
Fix gitignore again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ dist-ssr
 
 /__pycache__/
 /backend/__pycache__/
-/backend/root_password.py
+/backend/database_link.py


### PR DESCRIPTION
I created a database_link.py file earlier, so I added that one to the gitignore instead of the previously used root_password.py